### PR TITLE
Fix loading of PR template from '.github' directory

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    git_reflow (0.8.4)
+    git_reflow (0.8.5)
       colorize (>= 0.7.0)
       github_api (= 0.14.0)
       gli (= 2.14.0)
@@ -21,7 +21,7 @@ GEM
     byebug (9.0.4)
     chronic (0.10.2)
     coderay (1.1.1)
-    colorize (0.7.7)
+    colorize (0.8.1)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     descendants_tracker (0.0.4)
@@ -39,26 +39,24 @@ GEM
       oauth2
     gli (2.14.0)
     hashdiff (0.3.0)
-    hashie (3.4.4)
+    hashie (3.4.6)
     highline (1.7.8)
-    httpclient (2.8.0)
+    httpclient (2.8.2.4)
     json (1.8.3)
-    jwt (1.5.4)
+    jwt (1.5.6)
     method_source (0.8.2)
     mini_portile2 (2.1.0)
     multi_json (1.12.1)
-    multi_xml (0.5.5)
+    multi_xml (0.6.0)
     multipart-post (2.0.0)
-    nokogiri (1.6.8)
+    nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
-      pkg-config (~> 1.1.7)
-    oauth2 (1.2.0)
-      faraday (>= 0.8, < 0.10)
+    oauth2 (1.3.0)
+      faraday (>= 0.8, < 0.11)
       jwt (~> 1.0)
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    pkg-config (1.1.7)
     pry (0.10.3)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -66,7 +64,7 @@ GEM
     pry-byebug (3.4.0)
       byebug (~> 9.0)
       pry (~> 0.10)
-    rack (1.6.4)
+    rack (1.6.5)
     rake (11.1.2)
     rdoc (4.2.2)
       json (~> 1.4)
@@ -117,4 +115,4 @@ DEPENDENCIES
   wwtd (= 1.3.0)
 
 BUNDLED WITH
-   1.12.5
+   1.13.7

--- a/lib/git_reflow/git_helpers.rb
+++ b/lib/git_reflow/git_helpers.rb
@@ -34,8 +34,8 @@ module GitReflow
     end
 
     def pull_request_template
-      filenames_to_try = %w( github/PULL_REQUEST_TEMPLATE.md
-                             github/PULL_REQUEST_TEMPLATE
+      filenames_to_try = %w( .github/PULL_REQUEST_TEMPLATE.md
+                             .github/PULL_REQUEST_TEMPLATE
                              PULL_REQUEST_TEMPLATE.md
                              PULL_REQUEST_TEMPLATE ).map do |file|
         "#{git_root_dir}/#{file}"

--- a/lib/git_reflow/version.rb
+++ b/lib/git_reflow/version.rb
@@ -1,3 +1,3 @@
 module GitReflow
-  VERSION = "0.8.4"
+  VERSION = "0.8.5"
 end

--- a/spec/lib/git_reflow/git_helpers_spec.rb
+++ b/spec/lib/git_reflow/git_helpers_spec.rb
@@ -82,8 +82,8 @@ describe GitReflow::GitHelpers do
 
       before do
         allow(Gitacular).to receive(:git_root_dir).and_return(root_dir)
-        allow(File).to receive(:exist?).with("#{root_dir}/github/PULL_REQUEST_TEMPLATE.md").and_return(true)
-        allow(File).to receive(:read).with("#{root_dir}/github/PULL_REQUEST_TEMPLATE.md").and_return(template_content)
+        allow(File).to receive(:exist?).with("#{root_dir}/.github/PULL_REQUEST_TEMPLATE.md").and_return(true)
+        allow(File).to receive(:read).with("#{root_dir}/.github/PULL_REQUEST_TEMPLATE.md").and_return(template_content)
       end
       it { is_expected.to eq template_content }
     end


### PR DESCRIPTION
Re-targets the lookup of the pull request template file to use `.github` instead of `github`
